### PR TITLE
Parse pdf improvements

### DIFF
--- a/features/support/pdf_parser.rb
+++ b/features/support/pdf_parser.rb
@@ -28,7 +28,10 @@ def parse_transaction_details(text)
 end
 
 def dividend_payment?(line)
-  line.match?(/\bDividend\b/) && (line.match?(/\bCash Dividend\b/) || line.match?(/\bNon-Qualified Div\b/))
+  line.match?(/\bDividend\b/) &&
+    (line.match?(/\bCash Dividend\b/) ||
+    line.match?(/\bNon-Qualified Div\b/) ||
+    line.match?(/\bQual. Dividend\b/))
 end
 
 def dividend_tax?(line)
@@ -53,5 +56,6 @@ def remove_line_breaks_from_category(text)
   text.gsub("NRA Tax\n", 'NRA Tax')
       .gsub("Cash Dividend\n", 'Cash Dividend')
       .gsub("Non-Qualified Div\n", 'Non-Qualified Div')
+      .gsub("Qual. Dividend\n", 'Qual. Dividend')
       .gsub("Credit Interest\n", 'Credit Interest')
 end

--- a/features/support/pdf_parser.rb
+++ b/features/support/pdf_parser.rb
@@ -18,13 +18,21 @@ def parse_transaction_details(text)
   text.each_line do |line|
     next if line.include? 'SYMBOL'
 
-    if line.include?('Cash Dividend') || line.include?('Non-Qualified Div') || line.include?('NRA Tax')
+    if dividend_payment?(line) || dividend_tax?(line)
       columns = line.strip.split(/\s{2,}/)
       transactions << columns
     end
   end
 
   transactions
+end
+
+def dividend_payment?(line)
+  line.match?(/\bDividend\b/) && (line.match?(/\bCash Dividend\b/) || line.match?(/\bNon-Qualified Div\b/))
+end
+
+def dividend_tax?(line)
+  line.match?(/\bDividend\b/) && line.match?(/\bNRA Tax\b/)
 end
 
 def parse_statement_period(text)
@@ -37,4 +45,5 @@ def remove_line_breaks_from_category(text)
   text.gsub("NRA Tax\n", 'NRA Tax')
       .gsub("Cash Dividend\n", 'Cash Dividend')
       .gsub("Non-Qualified Div\n", 'Non-Qualified Div')
+      .gsub("Credit Interest\n", 'Credit Interest')
 end

--- a/features/support/pdf_parser.rb
+++ b/features/support/pdf_parser.rb
@@ -18,7 +18,7 @@ def parse_transaction_details(text)
   text.each_line do |line|
     next if line.include? 'SYMBOL'
 
-    if dividend_payment?(line) || dividend_tax?(line)
+    if dividend_payment?(line) || dividend_tax?(line) || interest_payment?(line) || interest_tax?(line)
       columns = line.strip.split(/\s{2,}/)
       transactions << columns
     end
@@ -33,6 +33,14 @@ end
 
 def dividend_tax?(line)
   line.match?(/\bDividend\b/) && line.match?(/\bNRA Tax\b/)
+end
+
+def interest_payment?(line)
+  line.match?(/\Interest\b/) && line.match?(/\bCredit Interest\b/)
+end
+
+def interest_tax?(line)
+  line.match?(/\Interest\b/) && line.match?(/\bNRA Tax\b/)
 end
 
 def parse_statement_period(text)


### PR DESCRIPTION
Improvements to PDF parsing: only Transaction Details with category and action will be read. Cash Dividends from Income Summary and Pending transactions will not be processed.